### PR TITLE
Fix issue 29 : NotSupportedException: Parameter type not supported when creating test file.

### DIFF
--- a/Sandbox/Classes/Cases/ClassWithMethods.cs
+++ b/Sandbox/Classes/Cases/ClassWithMethods.cs
@@ -90,6 +90,16 @@ namespace UnitBoilerplate.Sandbox.Classes.Cases
 		{
 			return Task.FromResult(true);
 		}
+
+		public string MethodWithNullableArgument(int? argument)
+		{
+			return string.Empty;
+		}
+
+		public string MethodWithNamespaceQualifiedArgument(Classes.IInterface3 myInterface)
+		{
+			return string.Empty;
+		}
 	}
 
 	public enum Cucu

--- a/SelfTestFiles/Expected/NUnit_Moq_ClassWithMethods.cs
+++ b/SelfTestFiles/Expected/NUnit_Moq_ClassWithMethods.cs
@@ -252,5 +252,35 @@ namespace UnitTestBoilerplate.SelfTest.Cases
 			// Assert
 			Assert.Fail();
 		}
+
+		[Test]
+		public void MethodWithNullableArgument_StateUnderTest_ExpectedBehavior()
+		{
+			// Arrange
+			var unitUnderTest = CreateClassWithMethods();
+			int? argument = TODO;
+
+			// Act
+			var result = unitUnderTest.MethodWithNullableArgument(
+				argument);
+
+			// Assert
+			Assert.Fail();
+		}
+
+		[Test]
+		public void MethodWithNamespaceQualifiedArgument_StateUnderTest_ExpectedBehavior()
+		{
+			// Arrange
+			var unitUnderTest = CreateClassWithMethods();
+			Classes.IInterface3 myInterface = TODO;
+
+			// Act
+			var result = unitUnderTest.MethodWithNamespaceQualifiedArgument(
+				myInterface);
+
+			// Assert
+			Assert.Fail();
+		}
 	}
 }

--- a/SelfTestFiles/Expected/VisualStudio_AutoMoq_ClassWithMethods.cs
+++ b/SelfTestFiles/Expected/VisualStudio_AutoMoq_ClassWithMethods.cs
@@ -241,5 +241,37 @@ namespace UnitTestBoilerplate.SelfTest.Cases
 			// Assert
 			Assert.Fail();
 		}
+
+		[TestMethod]
+		public void MethodWithNullableArgument_StateUnderTest_ExpectedBehavior()
+		{
+			// Arrange
+			var mocker = new AutoMoqer();
+			var unitUnderTest = mocker.Create<ClassWithMethods>();
+			int? argument = TODO;
+
+			// Act
+			var result = unitUnderTest.MethodWithNullableArgument(
+				argument);
+
+			// Assert
+			Assert.Fail();
+		}
+
+		[TestMethod]
+		public void MethodWithNamespaceQualifiedArgument_StateUnderTest_ExpectedBehavior()
+		{
+			// Arrange
+			var mocker = new AutoMoqer();
+			var unitUnderTest = mocker.Create<ClassWithMethods>();
+			Classes.IInterface3 myInterface = TODO;
+
+			// Act
+			var result = unitUnderTest.MethodWithNamespaceQualifiedArgument(
+				myInterface);
+
+			// Assert
+			Assert.Fail();
+		}
 	}
 }

--- a/SelfTestFiles/Expected/VisualStudio_Moq_ClassWithMethods.cs
+++ b/SelfTestFiles/Expected/VisualStudio_Moq_ClassWithMethods.cs
@@ -252,5 +252,35 @@ namespace UnitTestBoilerplate.SelfTest.Cases
 			// Assert
 			Assert.Fail();
 		}
+
+		[TestMethod]
+		public void MethodWithNullableArgument_StateUnderTest_ExpectedBehavior()
+		{
+			// Arrange
+			var unitUnderTest = CreateClassWithMethods();
+			int? argument = TODO;
+
+			// Act
+			var result = unitUnderTest.MethodWithNullableArgument(
+				argument);
+
+			// Assert
+			Assert.Fail();
+		}
+
+		[TestMethod]
+		public void MethodWithNamespaceQualifiedArgument_StateUnderTest_ExpectedBehavior()
+		{
+			// Arrange
+			var unitUnderTest = CreateClassWithMethods();
+			Classes.IInterface3 myInterface = TODO;
+
+			// Act
+			var result = unitUnderTest.MethodWithNamespaceQualifiedArgument(
+				myInterface);
+
+			// Assert
+			Assert.Fail();
+		}
 	}
 }

--- a/SelfTestFiles/Expected/VisualStudio_NSubstitute_ClassWithMethods.cs
+++ b/SelfTestFiles/Expected/VisualStudio_NSubstitute_ClassWithMethods.cs
@@ -243,5 +243,35 @@ namespace UnitTestBoilerplate.SelfTest.Cases
 			// Assert
 			Assert.Fail();
 		}
+
+		[TestMethod]
+		public void MethodWithNullableArgument_StateUnderTest_ExpectedBehavior()
+		{
+			// Arrange
+			var unitUnderTest = CreateClassWithMethods();
+			int? argument = TODO;
+
+			// Act
+			var result = unitUnderTest.MethodWithNullableArgument(
+				argument);
+
+			// Assert
+			Assert.Fail();
+		}
+
+		[TestMethod]
+		public void MethodWithNamespaceQualifiedArgument_StateUnderTest_ExpectedBehavior()
+		{
+			// Arrange
+			var unitUnderTest = CreateClassWithMethods();
+			Classes.IInterface3 myInterface = TODO;
+
+			// Act
+			var result = unitUnderTest.MethodWithNamespaceQualifiedArgument(
+				myInterface);
+
+			// Assert
+			Assert.Fail();
+		}
 	}
 }

--- a/SelfTestFiles/Expected/VisualStudio_Rhino Mocks_ClassWithMethods.cs
+++ b/SelfTestFiles/Expected/VisualStudio_Rhino Mocks_ClassWithMethods.cs
@@ -243,5 +243,35 @@ namespace UnitTestBoilerplate.SelfTest.Cases
 			// Assert
 			Assert.Fail();
 		}
+
+		[TestMethod]
+		public void MethodWithNullableArgument_StateUnderTest_ExpectedBehavior()
+		{
+			// Arrange
+			var unitUnderTest = CreateClassWithMethods();
+			int? argument = TODO;
+
+			// Act
+			var result = unitUnderTest.MethodWithNullableArgument(
+				argument);
+
+			// Assert
+			Assert.Fail();
+		}
+
+		[TestMethod]
+		public void MethodWithNamespaceQualifiedArgument_StateUnderTest_ExpectedBehavior()
+		{
+			// Arrange
+			var unitUnderTest = CreateClassWithMethods();
+			Classes.IInterface3 myInterface = TODO;
+
+			// Act
+			var result = unitUnderTest.MethodWithNamespaceQualifiedArgument(
+				myInterface);
+
+			// Assert
+			Assert.Fail();
+		}
 	}
 }

--- a/SelfTestFiles/Expected/VisualStudio_SimpleStubs_ClassWithMethods.cs
+++ b/SelfTestFiles/Expected/VisualStudio_SimpleStubs_ClassWithMethods.cs
@@ -242,5 +242,35 @@ namespace UnitTestBoilerplate.SelfTest.Cases
 			// Assert
 			Assert.Fail();
 		}
+
+		[TestMethod]
+		public void MethodWithNullableArgument_StateUnderTest_ExpectedBehavior()
+		{
+			// Arrange
+			var unitUnderTest = CreateClassWithMethods();
+			int? argument = TODO;
+
+			// Act
+			var result = unitUnderTest.MethodWithNullableArgument(
+				argument);
+
+			// Assert
+			Assert.Fail();
+		}
+
+		[TestMethod]
+		public void MethodWithNamespaceQualifiedArgument_StateUnderTest_ExpectedBehavior()
+		{
+			// Arrange
+			var unitUnderTest = CreateClassWithMethods();
+			Classes.IInterface3 myInterface = TODO;
+
+			// Act
+			var result = unitUnderTest.MethodWithNamespaceQualifiedArgument(
+				myInterface);
+
+			// Assert
+			Assert.Fail();
+		}
 	}
 }

--- a/SelfTestFiles/Expected/xUnit_Moq_ClassWithMethods.cs
+++ b/SelfTestFiles/Expected/xUnit_Moq_ClassWithMethods.cs
@@ -249,5 +249,35 @@ namespace UnitTestBoilerplate.SelfTest.Cases
 			// Assert
 			Assert.Fail();
 		}
+
+		[Fact]
+		public void MethodWithNullableArgument_StateUnderTest_ExpectedBehavior()
+		{
+			// Arrange
+			var unitUnderTest = CreateClassWithMethods();
+			int? argument = TODO;
+
+			// Act
+			var result = unitUnderTest.MethodWithNullableArgument(
+				argument);
+
+			// Assert
+			Assert.Fail();
+		}
+
+		[Fact]
+		public void MethodWithNamespaceQualifiedArgument_StateUnderTest_ExpectedBehavior()
+		{
+			// Arrange
+			var unitUnderTest = CreateClassWithMethods();
+			Classes.IInterface3 myInterface = TODO;
+
+			// Act
+			var result = unitUnderTest.MethodWithNamespaceQualifiedArgument(
+				myInterface);
+
+			// Assert
+			Assert.Fail();
+		}
 	}
 }

--- a/src/Services/TestGenerationService.cs
+++ b/src/Services/TestGenerationService.cs
@@ -315,7 +315,7 @@ namespace UnitTestBoilerplate.Services
 
 				var argumentType = argumentList[i].Type;
 
-				string typeName = GetSimpleTypeName(argumentType);
+				string typeName = argumentType.ToString();
 
 				argumentDescriptors[i] = new MethodArgumentDescriptor(new TypeDescriptor(typeName, null), argumentName, modifier);
 			}
@@ -336,43 +336,6 @@ namespace UnitTestBoilerplate.Services
 			}
 
 			return ParameterModifier.None;
-		}
-
-		private static string GetSimpleTypeName(TypeSyntax argumentType)
-		{
-			string typeName = string.Empty;
-
-			if (argumentType is PredefinedTypeSyntax predefinedType)
-			{
-				typeName = predefinedType.Keyword.ValueText;
-			}
-			else if (argumentType is IdentifierNameSyntax identifiedType)
-			{
-				typeName = identifiedType.Identifier.Text;
-			}
-			else if (argumentType is ArrayTypeSyntax arrayType)
-			{
-				var builder = new StringBuilder();
-
-				builder.Append(GetSimpleTypeName(arrayType.ElementType));
-
-				int dimension = arrayType.RankSpecifiers.Count;
-
-				for (int i = 0; i < dimension; i++)
-				{
-					builder.Append(
-						$"{arrayType.RankSpecifiers[i].OpenBracketToken.Text}" +
-						$"{arrayType.RankSpecifiers[i].CloseBracketToken.Text}");
-				}
-
-				typeName = builder.ToString();
-			}
-			else
-			{
-				throw new NotSupportedException("Parameter type not supported");
-			}
-
-			return typeName;
 		}
 
 		private static IEnumerable<ParameterSyntax> GetParameterListNodes(SyntaxNode memberNode)


### PR DESCRIPTION
- Fix test method generation for classes having public methods containing nullable or namespace-qualified argument types